### PR TITLE
Adding GitHub actions step to report status on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           distribution: temurin
           java-version: 11
 
-
       - name: Setup couchbase
         run: |
           apt install -y iputils-ping || echo "apt-install failed"
@@ -88,6 +87,18 @@ jobs:
 
       - name: Build project
         run: sbt ++${{ matrix.scala }} test
+
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure,warnings'
+          notification_title: 'Repo: *{repo}*'
+          message_format: '{emoji}    *{status_message}* in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>'
+          footer: '<{run_url}|View Full Run on GitHub>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
     services:
       couchbase:
         image: couchbase:enterprise-7.0.3


### PR DESCRIPTION
- This will ONLY run on failure
- It will alert us of any failure via the #da-alerts-failures slack channel
- It pulls the secret from the organization, so no additional configuration is required to make this work