### PR TITLE
Align CI with Scala 2.13.9 and JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
-        java: [temurin@11]
+        scala: [2.13.9]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -27,12 +27,13 @@ jobs:
         run: |
           apt update || echo "apt-update failed" # && apt -y upgrade
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
+          cache: sbt
 
       - name: Setup couchbase
         run: |
@@ -57,7 +58,7 @@ jobs:
             socat TCP-LISTEN:18096,fork TCP:couchbase:18096 &
           ) && echo "Initialized couchbase port forwarding" || echo "ping couchbase failed, not forwarding ports"
           printf "Waiting for CB startup..."
-          wget -O /dev/null  http://localhost:8091/ && echo "DONE" || (echo "FAIL" && panic)
+          wget -O /dev/null  http://localhost:8091/ && echo "DONE" || (echo "FAIL" && exit 1)
           curl  -v -X POST http://localhost:8091/node/controller/setupServices -d 'services=kv%2Cn1ql%2Cindex'
           curl  -v -X POST http://localhost:8091/pools/default -d 'memoryQuota=256' -d 'indexMemoryQuota=256'
           curl  -u Administrator:password -v -X POST http://localhost:8091/settings/web -d 'password=password&username=Administrator&port=SAME'
@@ -69,18 +70,6 @@ jobs:
             -d durabilityMinLevel=majorityAndPersistActive
           curl  -u Administrator:password -v -X POST http://localhost:8091/settings/indexes -d 'storageMode=memory_optimized'
           curl  -u Administrator:password -v -X GET http://localhost:8091/pools/default | jq '.' | grep hostname
-
-      - name: Cache sbt
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
 #      - name: Check that workflows are up to date
 #        run: sbt ++${{ matrix.scala }} githubWorkflowCheck


### PR DESCRIPTION
## Summary
- align the GitHub Actions matrix with the repo's current Scala/JDK baseline by moving CI to Scala 2.13.9 on Temurin 17
- update `actions/checkout` and `actions/setup-java` to current major versions and use setup-java's built-in sbt cache
- replace the undefined `panic` shell path in the Couchbase startup step with `exit 1`

## Verification
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64 sbt test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'`
- Launch the app on an alternate port to avoid an unrelated local `:8080` conflict and verify the Swagger/CRUD path:
  - `java -Dnetty.port=18080 -Dcouchbase.host=127.0.0.1 -cp <exported classpath> org.couchbase.scala.quickstart.Main`
  - `curl -L http://127.0.0.1:18080/docs`
  - `curl -X POST http://127.0.0.1:18080/api/v1/airline ...`
  - `curl http://127.0.0.1:18080/api/v1/airline?id=999001`
  - `curl -X DELETE http://127.0.0.1:18080/api/v1/airline?id=999001`

## Evidence
- `tutorial-maintenance/runs/scala-quickstart/2026-06-02T0145Z/verification.md`
- `tutorial-maintenance/runs/scala-quickstart/2026-06-02T0145Z/sbt-test.log`
- `tutorial-maintenance/runs/scala-quickstart/2026-06-02T0145Z/screenshots/swagger-docs.png`

## Notes
- `tutorial-maintenance/tutorials.json` still described this repo's CI as Scala 2.13.8 on JDK 11; this PR brings the workflow in line with the existing `build.sbt` / README surfaces.
- The local list endpoint walkthrough hit Couchbase query-service bulk-get/KV timeouts to `127.0.0.1:11210` after the temporary CRUD pass. I left that behavior out of scope here because this PR only updates CI/workflow plumbing and the CRUD walkthrough itself still passed.
- I attempted to capture a short Swagger video as well, but only the screenshot artifact landed cleanly in this run.

## Media evidence
- Auto-attached reviewer-facing media from the local verification artifacts captured during this run.
- This keeps the main PR body self-contained instead of relying on a follow-up comment for visual proof.

![Swagger Docs](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1780370249/pr-evidence/couchbase-examples/scala-quickstart/pr-10/swagger-docs.png)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/scala-quickstart/2026-06-02T0145Z/screenshots/swagger-docs.png`

</details>
